### PR TITLE
Fix DOM ad removal

### DIFF
--- a/js/theguardian.js
+++ b/js/theguardian.js
@@ -1,4 +1,9 @@
-var ad_id = document.getElementByClassName('top-banner-ad-container');
-document.body.removeChild(ad_id);
-var ad = document.getElementByClassName('ad-slot');
-document.body.removeChild(ad);
+var topBanners = document.getElementsByClassName('top-banner-ad-container');
+for (var i = topBanners.length - 1; i >= 0; i--) {
+  topBanners[i].remove();
+}
+
+var ads = document.getElementsByClassName('ad-slot');
+for (var i = ads.length - 1; i >= 0; i--) {
+  ads[i].remove();
+}


### PR DESCRIPTION
## Summary
- correct DOM API usage in The Guardian ad removal script

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68577f12f8e88327abe6bed330d734c7